### PR TITLE
Add fast MCQA

### DIFF
--- a/src/olmo_eval/metrics.py
+++ b/src/olmo_eval/metrics.py
@@ -145,7 +145,9 @@ class ICLMetric(Metric):
                     bpb_no_leading_space = bpb
                 elif self.metric_type == "acc" or self.metric_type == "f1":
                     # gather log-probs at continuation token indices
-                    log_likelihood = torch.gather(lm_cont_logits, 1, _cont_tokens.unsqueeze(-1)).sum()
+                    log_likelihood = torch.gather(
+                        lm_cont_logits, 1, _cont_tokens.unsqueeze(-1)
+                    ).sum()
                     celoss = (
                         -torch.gather(lm_cont_logits, 1, _cont_tokens.unsqueeze(-1)).sum()
                         / batch["cont_str_len"][idx]
@@ -207,7 +209,9 @@ class ICLMetric(Metric):
                 self.loglikelihoods_no_leading_space.append(
                     (doc_id, _cont_id, float(log_likelihood_no_leading_space))
                 )
-                self.celosses_no_leading_space.append((doc_id, _cont_id, float(celoss_no_leading_space)))
+                self.celosses_no_leading_space.append(
+                    (doc_id, _cont_id, float(celoss_no_leading_space))
+                )
                 self.bpbs_no_leading_space.append((doc_id, _cont_id, float(bpb_no_leading_space)))
 
     def compute(self) -> Dict[str, torch.Tensor]:

--- a/src/olmo_eval/tasks.py
+++ b/src/olmo_eval/tasks.py
@@ -1789,11 +1789,21 @@ LABEL_TO_TASK_MAP_ORIG = {
     ),
     "copycolors_10way_fast": (
         OEEvalTask,
-        {"dataset_path": "copycolors", "dataset_name": "10way", "metric_type": "acc", "fast_mc": True},
+        {
+            "dataset_path": "copycolors",
+            "dataset_name": "10way",
+            "metric_type": "acc",
+            "fast_mc": True,
+        },
     ),
     "copycolors_xl_10way_fast": (
         OEEvalTask,
-        {"dataset_path": "copycolors", "dataset_name": "xl_10way", "metric_type": "acc", "fast_mc": True},
+        {
+            "dataset_path": "copycolors",
+            "dataset_name": "xl_10way",
+            "metric_type": "acc",
+            "fast_mc": True,
+        },
     ),
     "csqa_mc_5shot": (
         OEEvalTask,
@@ -2083,7 +2093,12 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "arc_easy_val_mc_5shot_fast": (
         OEEvalTask,
-        {"dataset_path": "arc_easy", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
+        {
+            "dataset_path": "arc_easy",
+            "dataset_name": "val_mc_5shot",
+            "metric_type": "acc",
+            "fast_mc": True,
+        },
     ),
     "arc_easy_test_rc_5shot": (
         OEEvalTask,
@@ -2099,7 +2114,12 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "arc_easy_test_mc_5shot_fast": (
         OEEvalTask,
-        {"dataset_path": "arc_easy", "dataset_name": "test_mc_5shot", "metric_type": "acc", "fast_mc": True},
+        {
+            "dataset_path": "arc_easy",
+            "dataset_name": "test_mc_5shot",
+            "metric_type": "acc",
+            "fast_mc": True,
+        },
     ),
     "boolq_val_rc_5shot": (
         OEEvalTask,
@@ -2115,7 +2135,12 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "boolq_val_mc_5shot_fast": (
         OEEvalTask,
-        {"dataset_path": "boolq", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
+        {
+            "dataset_path": "boolq",
+            "dataset_name": "val_mc_5shot",
+            "metric_type": "acc",
+            "fast_mc": True,
+        },
     ),
     "csqa_val_rc_5shot": (
         OEEvalTask,
@@ -2131,7 +2156,12 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "csqa_val_mc_5shot_fast": (
         OEEvalTask,
-        {"dataset_path": "csqa", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
+        {
+            "dataset_path": "csqa",
+            "dataset_name": "val_mc_5shot",
+            "metric_type": "acc",
+            "fast_mc": True,
+        },
     ),
     "hellaswag_val_rc_5shot": (
         OEEvalTask,
@@ -2147,7 +2177,12 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "hellaswag_val_mc_5shot_fast": (
         OEEvalTask,
-        {"dataset_path": "hellaswag", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
+        {
+            "dataset_path": "hellaswag",
+            "dataset_name": "val_mc_5shot",
+            "metric_type": "acc",
+            "fast_mc": True,
+        },
     ),
     "openbookqa_val_rc_5shot": (
         OEEvalTask,
@@ -2163,7 +2198,12 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "openbookqa_val_mc_5shot_fast": (
         OEEvalTask,
-        {"dataset_path": "openbookqa", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
+        {
+            "dataset_path": "openbookqa",
+            "dataset_name": "val_mc_5shot",
+            "metric_type": "acc",
+            "fast_mc": True,
+        },
     ),
     "openbookqa_test_rc_5shot": (
         OEEvalTask,
@@ -2179,7 +2219,12 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "openbookqa_test_mc_5shot_fast": (
         OEEvalTask,
-        {"dataset_path": "openbookqa", "dataset_name": "test_mc_5shot", "metric_type": "acc", "fast_mc": True},
+        {
+            "dataset_path": "openbookqa",
+            "dataset_name": "test_mc_5shot",
+            "metric_type": "acc",
+            "fast_mc": True,
+        },
     ),
     "piqa_val_rc_5shot": (
         OEEvalTask,
@@ -2195,7 +2240,12 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "piqa_val_mc_5shot_fast": (
         OEEvalTask,
-        {"dataset_path": "piqa", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
+        {
+            "dataset_path": "piqa",
+            "dataset_name": "val_mc_5shot",
+            "metric_type": "acc",
+            "fast_mc": True,
+        },
     ),
     "socialiqa_val_rc_5shot": (
         OEEvalTask,
@@ -2211,7 +2261,12 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "socialiqa_val_mc_5shot_fast": (
         OEEvalTask,
-        {"dataset_path": "socialiqa", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
+        {
+            "dataset_path": "socialiqa",
+            "dataset_name": "val_mc_5shot",
+            "metric_type": "acc",
+            "fast_mc": True,
+        },
     ),
     "winogrande_val_rc_5shot": (
         OEEvalTask,
@@ -2227,11 +2282,19 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "winogrande_val_mc_5shot_fast": (
         OEEvalTask,
-        {"dataset_path": "winogrande", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
+        {
+            "dataset_path": "winogrande",
+            "dataset_name": "val_mc_5shot",
+            "metric_type": "acc",
+            "fast_mc": True,
+        },
     ),
     "mmlu_stem_val_rc_var": (MMLU, {"dataset_name": "stem", "prompt_variations": 1}),
     "mmlu_stem_val_rc_5shot": (MMLU, {"dataset_name": "stem", "prompt_variations": 2}),
-    "mmlu_stem_val_rc_5shot": (MMLU, {"dataset_name": "stem", "prompt_variations": 2, "metric_type": "bpb"}),
+    "mmlu_stem_val_bpb_5shot": (
+        MMLU,
+        {"dataset_name": "stem", "prompt_variations": 1, "metric_type": "bpb"},
+    ),
     "mmlu_stem_val_mc_5shot": (
         MMLU,
         {"dataset_name": "stem", "prompt_variations": 2, "mc_labels": True},
@@ -2262,12 +2325,24 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "mmlu_stem_test_mc_5shot_fast": (
         MMLU,
-        {"dataset_name": "stem", "split": "test", "prompt_variations": 2, "mc_labels": True, "fast_mc": True},
+        {
+            "dataset_name": "stem",
+            "split": "test",
+            "prompt_variations": 2,
+            "mc_labels": True,
+            "fast_mc": True,
+        },
     ),
     "mmlu_humanities_val_rc_var": (MMLU, {"dataset_name": "humanities", "prompt_variations": 1}),
     "mmlu_humanities_val_rc_5shot": (MMLU, {"dataset_name": "humanities", "prompt_variations": 2}),
-    "mmlu_humanities_val_bpb_var": (MMLU, {"dataset_name": "humanities", "prompt_variations": 1, "metric_type": "bpb"}),
-    "mmlu_humanities_val_bpb_5shot": (MMLU, {"dataset_name": "humanities", "prompt_variations": 1, "metric_type": "bpb"}),
+    "mmlu_humanities_val_bpb_var": (
+        MMLU,
+        {"dataset_name": "humanities", "prompt_variations": 1, "metric_type": "bpb"},
+    ),
+    "mmlu_humanities_val_bpb_5shot": (
+        MMLU,
+        {"dataset_name": "humanities", "prompt_variations": 1, "metric_type": "bpb"},
+    ),
     "mmlu_humanities_val_mc_5shot": (
         MMLU,
         {"dataset_name": "humanities", "prompt_variations": 2, "mc_labels": True},
@@ -2286,11 +2361,21 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "mmlu_humanities_test_bpb_var": (
         MMLU,
-        {"dataset_name": "humanities", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+        {
+            "dataset_name": "humanities",
+            "split": "test",
+            "prompt_variations": 1,
+            "metric_type": "bpb",
+        },
     ),
     "mmlu_humanities_test_bpb_5shot": (
         MMLU,
-        {"dataset_name": "humanities", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+        {
+            "dataset_name": "humanities",
+            "split": "test",
+            "prompt_variations": 1,
+            "metric_type": "bpb",
+        },
     ),
     "mmlu_humanities_test_mc_5shot": (
         MMLU,
@@ -2298,7 +2383,13 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "mmlu_humanities_test_mc_5shot_fast": (
         MMLU,
-        {"dataset_name": "humanities", "split": "test", "prompt_variations": 2, "mc_labels": True, "fast_mc": True},
+        {
+            "dataset_name": "humanities",
+            "split": "test",
+            "prompt_variations": 2,
+            "mc_labels": True,
+            "fast_mc": True,
+        },
     ),
     "mmlu_social_sciences_val_rc_var": (
         MMLU,
@@ -2322,7 +2413,12 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "mmlu_social_sciences_val_mc_5shot_fast": (
         MMLU,
-        {"dataset_name": "social_sciences", "prompt_variations": 2, "mc_labels": True, "fast_mc": True},
+        {
+            "dataset_name": "social_sciences",
+            "prompt_variations": 2,
+            "mc_labels": True,
+            "fast_mc": True,
+        },
     ),
     "mmlu_social_sciences_test_rc_var": (
         MMLU,
@@ -2334,11 +2430,21 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "mmlu_social_sciences_test_bpb_var": (
         MMLU,
-        {"dataset_name": "social_sciences", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+        {
+            "dataset_name": "social_sciences",
+            "split": "test",
+            "prompt_variations": 1,
+            "metric_type": "bpb",
+        },
     ),
     "mmlu_social_sciences_test_bpb_5shot": (
         MMLU,
-        {"dataset_name": "social_sciences", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+        {
+            "dataset_name": "social_sciences",
+            "split": "test",
+            "prompt_variations": 1,
+            "metric_type": "bpb",
+        },
     ),
     "mmlu_social_sciences_test_mc_5shot": (
         MMLU,
@@ -2356,13 +2462,19 @@ LABEL_TO_TASK_MAP_LADDER = {
             "split": "test",
             "prompt_variations": 2,
             "mc_labels": True,
-            "fast_mc": True
+            "fast_mc": True,
         },
     ),
     "mmlu_other_val_rc_var": (MMLU, {"dataset_name": "other", "prompt_variations": 1}),
     "mmlu_other_val_rc_5shot": (MMLU, {"dataset_name": "other", "prompt_variations": 2}),
-    "mmlu_other_val_bpb_var": (MMLU, {"dataset_name": "other", "prompt_variations": 1, "metric_type": "bpb"}),
-    "mmlu_other_val_bpb_5shot": (MMLU, {"dataset_name": "other", "prompt_variations": 1, "metric_type": "bpb"}),
+    "mmlu_other_val_bpb_var": (
+        MMLU,
+        {"dataset_name": "other", "prompt_variations": 1, "metric_type": "bpb"},
+    ),
+    "mmlu_other_val_bpb_5shot": (
+        MMLU,
+        {"dataset_name": "other", "prompt_variations": 1, "metric_type": "bpb"},
+    ),
     "mmlu_other_val_mc_5shot": (
         MMLU,
         {"dataset_name": "other", "prompt_variations": 2, "mc_labels": True},
@@ -2391,10 +2503,15 @@ LABEL_TO_TASK_MAP_LADDER = {
         MMLU,
         {"dataset_name": "other", "split": "test", "prompt_variations": 2, "mc_labels": True},
     ),
-
     "mmlu_other_test_mc_5shot_fast": (
         MMLU,
-        {"dataset_name": "other", "split": "test", "prompt_variations": 2, "mc_labels": True, "fast_mc": True},
+        {
+            "dataset_name": "other",
+            "split": "test",
+            "prompt_variations": 2,
+            "mc_labels": True,
+            "fast_mc": True,
+        },
     ),
 }
 

--- a/src/olmo_eval/tasks.py
+++ b/src/olmo_eval/tasks.py
@@ -1880,6 +1880,10 @@ LABEL_TO_TASK_MAP_ORIG = {
         OEEvalTask,
         {"dataset_path": "hellaswag", "dataset_name": "rc_5shot", "metric_type": "len_norm"},
     ),
+    "hellaswag_bpb_5shot": (
+        OEEvalTask,
+        {"dataset_path": "hellaswag", "dataset_name": "rc_5shot", "metric_type": "bpb"},
+    ),
     "openbookqa_mc_5shot": (
         OEEvalTask,
         {"dataset_path": "openbookqa", "dataset_name": "mc_5shot", "metric_type": "acc"},
@@ -2344,7 +2348,7 @@ LABEL_TO_TASK_MAP_LADDER = {
     "mmlu_stem_val_rc_5shot": (MMLU, {"dataset_name": "stem", "prompt_variations": 2}),
     "mmlu_stem_val_bpb_5shot": (
         MMLU,
-        {"dataset_name": "stem", "prompt_variations": 1, "metric_type": "bpb"},
+        {"dataset_name": "stem", "prompt_variations": 2, "metric_type": "bpb"},
     ),
     "mmlu_stem_val_mc_5shot": (
         MMLU,
@@ -2360,7 +2364,7 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "mmlu_stem_test_bpb_var": (
         MMLU,
-        {"dataset_name": "stem", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+        {"dataset_name": "stem", "split": "test", "prompt_variations": 2, "metric_type": "bpb"},
     ),
     "mmlu_stem_test_rc_5shot": (
         MMLU,
@@ -2368,7 +2372,7 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "mmlu_stem_test_bpb_5shot": (
         MMLU,
-        {"dataset_name": "stem", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+        {"dataset_name": "stem", "split": "test", "prompt_variations": 2, "metric_type": "bpb"},
     ),
     "mmlu_stem_test_mc_5shot": (
         MMLU,
@@ -2388,11 +2392,11 @@ LABEL_TO_TASK_MAP_LADDER = {
     "mmlu_humanities_val_rc_5shot": (MMLU, {"dataset_name": "humanities", "prompt_variations": 2}),
     "mmlu_humanities_val_bpb_var": (
         MMLU,
-        {"dataset_name": "humanities", "prompt_variations": 1, "metric_type": "bpb"},
+        {"dataset_name": "humanities", "prompt_variations": 2, "metric_type": "bpb"},
     ),
     "mmlu_humanities_val_bpb_5shot": (
         MMLU,
-        {"dataset_name": "humanities", "prompt_variations": 1, "metric_type": "bpb"},
+        {"dataset_name": "humanities", "prompt_variations": 2, "metric_type": "bpb"},
     ),
     "mmlu_humanities_val_mc_5shot": (
         MMLU,
@@ -2415,7 +2419,7 @@ LABEL_TO_TASK_MAP_LADDER = {
         {
             "dataset_name": "humanities",
             "split": "test",
-            "prompt_variations": 1,
+            "prompt_variations": 2,
             "metric_type": "bpb",
         },
     ),
@@ -2424,7 +2428,7 @@ LABEL_TO_TASK_MAP_LADDER = {
         {
             "dataset_name": "humanities",
             "split": "test",
-            "prompt_variations": 1,
+            "prompt_variations": 2,
             "metric_type": "bpb",
         },
     ),
@@ -2452,11 +2456,11 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "mmlu_social_sciences_val_bpb_var": (
         MMLU,
-        {"dataset_name": "social_sciences", "prompt_variations": 1, "metric_type": "bpb"},
+        {"dataset_name": "social_sciences", "prompt_variations": 2, "metric_type": "bpb"},
     ),
     "mmlu_social_sciences_val_bpb_5shot": (
         MMLU,
-        {"dataset_name": "social_sciences", "prompt_variations": 1, "metric_type": "bpb"},
+        {"dataset_name": "social_sciences", "prompt_variations": 2, "metric_type": "bpb"},
     ),
     "mmlu_social_sciences_val_mc_5shot": (
         MMLU,
@@ -2484,7 +2488,7 @@ LABEL_TO_TASK_MAP_LADDER = {
         {
             "dataset_name": "social_sciences",
             "split": "test",
-            "prompt_variations": 1,
+            "prompt_variations": 2,
             "metric_type": "bpb",
         },
     ),
@@ -2493,7 +2497,7 @@ LABEL_TO_TASK_MAP_LADDER = {
         {
             "dataset_name": "social_sciences",
             "split": "test",
-            "prompt_variations": 1,
+            "prompt_variations": 2,
             "metric_type": "bpb",
         },
     ),
@@ -2520,11 +2524,11 @@ LABEL_TO_TASK_MAP_LADDER = {
     "mmlu_other_val_rc_5shot": (MMLU, {"dataset_name": "other", "prompt_variations": 2}),
     "mmlu_other_val_bpb_var": (
         MMLU,
-        {"dataset_name": "other", "prompt_variations": 1, "metric_type": "bpb"},
+        {"dataset_name": "other", "prompt_variations": 2, "metric_type": "bpb"},
     ),
     "mmlu_other_val_bpb_5shot": (
         MMLU,
-        {"dataset_name": "other", "prompt_variations": 1, "metric_type": "bpb"},
+        {"dataset_name": "other", "prompt_variations": 2, "metric_type": "bpb"},
     ),
     "mmlu_other_val_mc_5shot": (
         MMLU,
@@ -2544,11 +2548,11 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "mmlu_other_test_bpb_var": (
         MMLU,
-        {"dataset_name": "other", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+        {"dataset_name": "other", "split": "test", "prompt_variations": 2, "metric_type": "bpb"},
     ),
     "mmlu_other_test_bpb_5shot": (
         MMLU,
-        {"dataset_name": "other", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+        {"dataset_name": "other", "split": "test", "prompt_variations": 2, "metric_type": "bpb"},
     ),
     "mmlu_other_test_mc_5shot": (
         MMLU,

--- a/src/olmo_eval/tasks.py
+++ b/src/olmo_eval/tasks.py
@@ -288,7 +288,7 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
 
         if self.fast_mc:
             # Pad choice_ids with -1 (for Qs with different numbers of choices)
-            max_choices_len = max(len(choices) for choices in choice_ids)        
+            max_choices_len = max(len(choices) for choices in choice_ids)
             padded_choice_ids = []
             for choices in choice_ids:
                 padding = [-1] * (max_choices_len - len(choices))
@@ -1517,7 +1517,7 @@ class OEEvalTask(ICLMultiChoiceTaskDataset):
         for requests in self.dataset:
             current_doc_id_offset += max_doc_id
             max_doc_id = 0  # Max doc id seen in this dataset
-            
+
             new_samples = []
             for request in requests:
                 doc = request["doc"]
@@ -1610,7 +1610,7 @@ class OEEvalTask(ICLMultiChoiceTaskDataset):
                         "label_id": label_id,
                     }
                 )
-            
+
             # Fast MCQA:
             # Only pass a single request, and group together all continuations as tokens
             if self.fast_mc:
@@ -1624,31 +1624,32 @@ class OEEvalTask(ICLMultiChoiceTaskDataset):
                 for doc_id in unique_doc_ids:
                     # Get all samples for this doc_id
                     doc_samples = [s for s in new_samples if s["doc_id"] == doc_id]
-                    
+
                     # Sort by continuation ID
                     doc_samples.sort(key=lambda x: x["cont_id"])
-                    
+
                     # Create new sample with distractor continuations
                     base_sample = doc_samples[0].copy()
                     choices = [s["continuation"] for s in doc_samples]
-                    
+
                     # Assert all continuations are length 1
                     for choice in choices:
-                        assert len(choice) == 1, f"Expected continuation length 1, got {len(choice)}"
-                    
+                        assert (
+                            len(choice) == 1
+                        ), f"Expected continuation length 1, got {len(choice)}"
+
                     # Take first token of each continuation
                     choices = [choice[0] for choice in choices]
-                    
+
                     base_sample["choices"] = choices
                     base_sample["fast_mc"] = True
-                    
+
                     fast_mc_samples.append(base_sample)
 
                 # Add fast MC samples to main samples list
                 new_samples = fast_mc_samples
 
             self.samples = new_samples
-
 
     def doc_to_text(self, doc) -> str:
         del doc
@@ -2037,7 +2038,12 @@ LABEL_TO_TASK_MAP_LADDER = {
     ),
     "arc_challenge_test_mc_5shot_fast": (
         OEEvalTask,
-        {"dataset_path": "arc_challenge", "dataset_name": "test_mc_5shot", "metric_type": "acc", "fast_mc": True},
+        {
+            "dataset_path": "arc_challenge",
+            "dataset_name": "test_mc_5shot",
+            "metric_type": "acc",
+            "fast_mc": True,
+        },
     ),
     "arc_easy_val_rc_5shot": (
         OEEvalTask,

--- a/src/olmo_eval/tasks.py
+++ b/src/olmo_eval/tasks.py
@@ -80,7 +80,6 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
         doc_id = 0
         new_samples = []
         for doc in self.dataset:
-
             for prompt in self.prompts:
                 self.current_prompt = prompt
                 # from EAI harness
@@ -175,9 +174,7 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
 
                 # Assert all continuations are length 1
                 for choice in choices:
-                    assert (
-                        len(choice) == 1
-                    ), f"Expected continuation length 1, got {len(choice)}"
+                    assert len(choice) == 1, f"Expected continuation length 1, got {len(choice)}"
 
                 # Take first token of each continuation
                 choices = [choice[0] for choice in choices]

--- a/src/olmo_eval/tasks.py
+++ b/src/olmo_eval/tasks.py
@@ -1787,6 +1787,14 @@ LABEL_TO_TASK_MAP_ORIG = {
         OEEvalTask,
         {"dataset_path": "copycolors", "dataset_name": "xl_10way", "metric_type": "acc"},
     ),
+    "copycolors_10way_fast": (
+        OEEvalTask,
+        {"dataset_path": "copycolors", "dataset_name": "10way", "metric_type": "acc", "fast_mc": True},
+    ),
+    "copycolors_xl_10way_fast": (
+        OEEvalTask,
+        {"dataset_path": "copycolors", "dataset_name": "xl_10way", "metric_type": "acc", "fast_mc": True},
+    ),
     "csqa_mc_5shot": (
         OEEvalTask,
         {"dataset_path": "csqa", "dataset_name": "mc_5shot", "metric_type": "acc"},
@@ -2020,6 +2028,14 @@ LABEL_TO_TASK_MAP_LADDER = {
             "metric_type": "len_norm",
         },
     ),
+    "arc_challenge_val_bpb_5shot": (
+        OEEvalTask,
+        {
+            "dataset_path": "arc_challenge",
+            "dataset_name": "val_rc_5shot",
+            "metric_type": "bpb",
+        },
+    ),
     "arc_challenge_val_mc_5shot": (
         OEEvalTask,
         {"dataset_path": "arc_challenge", "dataset_name": "val_mc_5shot", "metric_type": "acc"},
@@ -2030,6 +2046,14 @@ LABEL_TO_TASK_MAP_LADDER = {
             "dataset_path": "arc_challenge",
             "dataset_name": "test_rc_5shot",
             "metric_type": "len_norm",
+        },
+    ),
+    "arc_challenge_test_bpb_5shot": (
+        OEEvalTask,
+        {
+            "dataset_path": "arc_challenge",
+            "dataset_name": "test_rc_5shot",
+            "metric_type": "bpb",
         },
     ),
     "arc_challenge_test_mc_5shot": (
@@ -2049,105 +2073,208 @@ LABEL_TO_TASK_MAP_LADDER = {
         OEEvalTask,
         {"dataset_path": "arc_easy", "dataset_name": "val_rc_5shot", "metric_type": "len_norm"},
     ),
+    "arc_easy_val_bpb_5shot": (
+        OEEvalTask,
+        {"dataset_path": "arc_easy", "dataset_name": "val_rc_5shot", "metric_type": "bpb"},
+    ),
     "arc_easy_val_mc_5shot": (
         OEEvalTask,
         {"dataset_path": "arc_easy", "dataset_name": "val_mc_5shot", "metric_type": "acc"},
+    ),
+    "arc_easy_val_mc_5shot_fast": (
+        OEEvalTask,
+        {"dataset_path": "arc_easy", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
     ),
     "arc_easy_test_rc_5shot": (
         OEEvalTask,
         {"dataset_path": "arc_easy", "dataset_name": "test_rc_5shot", "metric_type": "len_norm"},
     ),
+    "arc_easy_test_bpb_5shot": (
+        OEEvalTask,
+        {"dataset_path": "arc_easy", "dataset_name": "test_rc_5shot", "metric_type": "bpb"},
+    ),
     "arc_easy_test_mc_5shot": (
         OEEvalTask,
         {"dataset_path": "arc_easy", "dataset_name": "test_mc_5shot", "metric_type": "acc"},
+    ),
+    "arc_easy_test_mc_5shot_fast": (
+        OEEvalTask,
+        {"dataset_path": "arc_easy", "dataset_name": "test_mc_5shot", "metric_type": "acc", "fast_mc": True},
     ),
     "boolq_val_rc_5shot": (
         OEEvalTask,
         {"dataset_path": "boolq", "dataset_name": "val_rc_5shot", "metric_type": "acc"},
     ),
+    "boolq_val_bpb_5shot": (
+        OEEvalTask,
+        {"dataset_path": "boolq", "dataset_name": "val_rc_5shot", "metric_type": "bpb"},
+    ),
     "boolq_val_mc_5shot": (
         OEEvalTask,
         {"dataset_path": "boolq", "dataset_name": "val_mc_5shot", "metric_type": "acc"},
+    ),
+    "boolq_val_mc_5shot_fast": (
+        OEEvalTask,
+        {"dataset_path": "boolq", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
     ),
     "csqa_val_rc_5shot": (
         OEEvalTask,
         {"dataset_path": "csqa", "dataset_name": "val_rc_5shot", "metric_type": "len_norm"},
     ),
+    "csqa_val_bpb_5shot": (
+        OEEvalTask,
+        {"dataset_path": "csqa", "dataset_name": "val_rc_5shot", "metric_type": "bpb"},
+    ),
     "csqa_val_mc_5shot": (
         OEEvalTask,
         {"dataset_path": "csqa", "dataset_name": "val_mc_5shot", "metric_type": "acc"},
+    ),
+    "csqa_val_mc_5shot_fast": (
+        OEEvalTask,
+        {"dataset_path": "csqa", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
     ),
     "hellaswag_val_rc_5shot": (
         OEEvalTask,
         {"dataset_path": "hellaswag", "dataset_name": "val_rc_5shot", "metric_type": "len_norm"},
     ),
+    "hellaswag_val_bpb_5shot": (
+        OEEvalTask,
+        {"dataset_path": "hellaswag", "dataset_name": "val_rc_5shot", "metric_type": "bpb"},
+    ),
     "hellaswag_val_mc_5shot": (
         OEEvalTask,
         {"dataset_path": "hellaswag", "dataset_name": "val_mc_5shot", "metric_type": "acc"},
+    ),
+    "hellaswag_val_mc_5shot_fast": (
+        OEEvalTask,
+        {"dataset_path": "hellaswag", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
     ),
     "openbookqa_val_rc_5shot": (
         OEEvalTask,
         {"dataset_path": "openbookqa", "dataset_name": "val_rc_5shot", "metric_type": "len_norm"},
     ),
+    "openbookqa_val_bpb_5shot": (
+        OEEvalTask,
+        {"dataset_path": "openbookqa", "dataset_name": "val_rc_5shot", "metric_type": "bpb"},
+    ),
     "openbookqa_val_mc_5shot": (
         OEEvalTask,
         {"dataset_path": "openbookqa", "dataset_name": "val_mc_5shot", "metric_type": "acc"},
+    ),
+    "openbookqa_val_mc_5shot_fast": (
+        OEEvalTask,
+        {"dataset_path": "openbookqa", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
     ),
     "openbookqa_test_rc_5shot": (
         OEEvalTask,
         {"dataset_path": "openbookqa", "dataset_name": "test_rc_5shot", "metric_type": "len_norm"},
     ),
+    "openbookqa_test_bpb_5shot": (
+        OEEvalTask,
+        {"dataset_path": "openbookqa", "dataset_name": "test_rc_5shot", "metric_type": "bpb"},
+    ),
     "openbookqa_test_mc_5shot": (
         OEEvalTask,
         {"dataset_path": "openbookqa", "dataset_name": "test_mc_5shot", "metric_type": "acc"},
+    ),
+    "openbookqa_test_mc_5shot_fast": (
+        OEEvalTask,
+        {"dataset_path": "openbookqa", "dataset_name": "test_mc_5shot", "metric_type": "acc", "fast_mc": True},
     ),
     "piqa_val_rc_5shot": (
         OEEvalTask,
         {"dataset_path": "piqa", "dataset_name": "val_rc_5shot", "metric_type": "len_norm"},
     ),
+    "piqa_val_bpb_5shot": (
+        OEEvalTask,
+        {"dataset_path": "piqa", "dataset_name": "val_rc_5shot", "metric_type": "bpb"},
+    ),
     "piqa_val_mc_5shot": (
         OEEvalTask,
         {"dataset_path": "piqa", "dataset_name": "val_mc_5shot", "metric_type": "acc"},
+    ),
+    "piqa_val_mc_5shot_fast": (
+        OEEvalTask,
+        {"dataset_path": "piqa", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
     ),
     "socialiqa_val_rc_5shot": (
         OEEvalTask,
         {"dataset_path": "socialiqa", "dataset_name": "val_rc_5shot", "metric_type": "len_norm"},
     ),
+    "socialiqa_val_bpb_5shot": (
+        OEEvalTask,
+        {"dataset_path": "socialiqa", "dataset_name": "val_rc_5shot", "metric_type": "bpb"},
+    ),
     "socialiqa_val_mc_5shot": (
         OEEvalTask,
         {"dataset_path": "socialiqa", "dataset_name": "val_mc_5shot", "metric_type": "acc"},
+    ),
+    "socialiqa_val_mc_5shot_fast": (
+        OEEvalTask,
+        {"dataset_path": "socialiqa", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
     ),
     "winogrande_val_rc_5shot": (
         OEEvalTask,
         {"dataset_path": "winogrande", "dataset_name": "val_rc_5shot", "metric_type": "len_norm"},
     ),
+    "winogrande_val_bpb_5shot": (
+        OEEvalTask,
+        {"dataset_path": "winogrande", "dataset_name": "val_rc_5shot", "metric_type": "bpb"},
+    ),
     "winogrande_val_mc_5shot": (
         OEEvalTask,
         {"dataset_path": "winogrande", "dataset_name": "val_mc_5shot", "metric_type": "acc"},
     ),
+    "winogrande_val_mc_5shot_fast": (
+        OEEvalTask,
+        {"dataset_path": "winogrande", "dataset_name": "val_mc_5shot", "metric_type": "acc", "fast_mc": True},
+    ),
     "mmlu_stem_val_rc_var": (MMLU, {"dataset_name": "stem", "prompt_variations": 1}),
     "mmlu_stem_val_rc_5shot": (MMLU, {"dataset_name": "stem", "prompt_variations": 2}),
+    "mmlu_stem_val_rc_5shot": (MMLU, {"dataset_name": "stem", "prompt_variations": 2, "metric_type": "bpb"}),
     "mmlu_stem_val_mc_5shot": (
         MMLU,
         {"dataset_name": "stem", "prompt_variations": 2, "mc_labels": True},
+    ),
+    "mmlu_stem_val_mc_5shot_fast": (
+        MMLU,
+        {"dataset_name": "stem", "prompt_variations": 2, "mc_labels": True, "fast_mc": True},
     ),
     "mmlu_stem_test_rc_var": (
         MMLU,
         {"dataset_name": "stem", "split": "test", "prompt_variations": 1},
     ),
+    "mmlu_stem_test_bpb_var": (
+        MMLU,
+        {"dataset_name": "stem", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+    ),
     "mmlu_stem_test_rc_5shot": (
         MMLU,
         {"dataset_name": "stem", "split": "test", "prompt_variations": 2},
+    ),
+    "mmlu_stem_test_bpb_5shot": (
+        MMLU,
+        {"dataset_name": "stem", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
     ),
     "mmlu_stem_test_mc_5shot": (
         MMLU,
         {"dataset_name": "stem", "split": "test", "prompt_variations": 2, "mc_labels": True},
     ),
+    "mmlu_stem_test_mc_5shot_fast": (
+        MMLU,
+        {"dataset_name": "stem", "split": "test", "prompt_variations": 2, "mc_labels": True, "fast_mc": True},
+    ),
     "mmlu_humanities_val_rc_var": (MMLU, {"dataset_name": "humanities", "prompt_variations": 1}),
     "mmlu_humanities_val_rc_5shot": (MMLU, {"dataset_name": "humanities", "prompt_variations": 2}),
+    "mmlu_humanities_val_bpb_var": (MMLU, {"dataset_name": "humanities", "prompt_variations": 1, "metric_type": "bpb"}),
+    "mmlu_humanities_val_bpb_5shot": (MMLU, {"dataset_name": "humanities", "prompt_variations": 1, "metric_type": "bpb"}),
     "mmlu_humanities_val_mc_5shot": (
         MMLU,
         {"dataset_name": "humanities", "prompt_variations": 2, "mc_labels": True},
+    ),
+    "mmlu_humanities_val_mc_5shot_fast": (
+        MMLU,
+        {"dataset_name": "humanities", "prompt_variations": 2, "mc_labels": True, "fast_mc": True},
     ),
     "mmlu_humanities_test_rc_var": (
         MMLU,
@@ -2157,9 +2284,21 @@ LABEL_TO_TASK_MAP_LADDER = {
         MMLU,
         {"dataset_name": "humanities", "split": "test", "prompt_variations": 2},
     ),
+    "mmlu_humanities_test_bpb_var": (
+        MMLU,
+        {"dataset_name": "humanities", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+    ),
+    "mmlu_humanities_test_bpb_5shot": (
+        MMLU,
+        {"dataset_name": "humanities", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+    ),
     "mmlu_humanities_test_mc_5shot": (
         MMLU,
         {"dataset_name": "humanities", "split": "test", "prompt_variations": 2, "mc_labels": True},
+    ),
+    "mmlu_humanities_test_mc_5shot_fast": (
+        MMLU,
+        {"dataset_name": "humanities", "split": "test", "prompt_variations": 2, "mc_labels": True, "fast_mc": True},
     ),
     "mmlu_social_sciences_val_rc_var": (
         MMLU,
@@ -2169,9 +2308,21 @@ LABEL_TO_TASK_MAP_LADDER = {
         MMLU,
         {"dataset_name": "social_sciences", "prompt_variations": 2},
     ),
+    "mmlu_social_sciences_val_bpb_var": (
+        MMLU,
+        {"dataset_name": "social_sciences", "prompt_variations": 1, "metric_type": "bpb"},
+    ),
+    "mmlu_social_sciences_val_bpb_5shot": (
+        MMLU,
+        {"dataset_name": "social_sciences", "prompt_variations": 1, "metric_type": "bpb"},
+    ),
     "mmlu_social_sciences_val_mc_5shot": (
         MMLU,
         {"dataset_name": "social_sciences", "prompt_variations": 2, "mc_labels": True},
+    ),
+    "mmlu_social_sciences_val_mc_5shot_fast": (
+        MMLU,
+        {"dataset_name": "social_sciences", "prompt_variations": 2, "mc_labels": True, "fast_mc": True},
     ),
     "mmlu_social_sciences_test_rc_var": (
         MMLU,
@@ -2180,6 +2331,14 @@ LABEL_TO_TASK_MAP_LADDER = {
     "mmlu_social_sciences_test_rc_5shot": (
         MMLU,
         {"dataset_name": "social_sciences", "split": "test", "prompt_variations": 2},
+    ),
+    "mmlu_social_sciences_test_bpb_var": (
+        MMLU,
+        {"dataset_name": "social_sciences", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+    ),
+    "mmlu_social_sciences_test_bpb_5shot": (
+        MMLU,
+        {"dataset_name": "social_sciences", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
     ),
     "mmlu_social_sciences_test_mc_5shot": (
         MMLU,
@@ -2190,11 +2349,27 @@ LABEL_TO_TASK_MAP_LADDER = {
             "mc_labels": True,
         },
     ),
+    "mmlu_social_sciences_test_mc_5shot_fast": (
+        MMLU,
+        {
+            "dataset_name": "social_sciences",
+            "split": "test",
+            "prompt_variations": 2,
+            "mc_labels": True,
+            "fast_mc": True
+        },
+    ),
     "mmlu_other_val_rc_var": (MMLU, {"dataset_name": "other", "prompt_variations": 1}),
     "mmlu_other_val_rc_5shot": (MMLU, {"dataset_name": "other", "prompt_variations": 2}),
+    "mmlu_other_val_bpb_var": (MMLU, {"dataset_name": "other", "prompt_variations": 1, "metric_type": "bpb"}),
+    "mmlu_other_val_bpb_5shot": (MMLU, {"dataset_name": "other", "prompt_variations": 1, "metric_type": "bpb"}),
     "mmlu_other_val_mc_5shot": (
         MMLU,
         {"dataset_name": "other", "prompt_variations": 2, "mc_labels": True},
+    ),
+    "mmlu_other_val_mc_5shot_fast": (
+        MMLU,
+        {"dataset_name": "other", "prompt_variations": 2, "mc_labels": True, "fast_mc": True},
     ),
     "mmlu_other_test_rc_var": (
         MMLU,
@@ -2204,9 +2379,22 @@ LABEL_TO_TASK_MAP_LADDER = {
         MMLU,
         {"dataset_name": "other", "split": "test", "prompt_variations": 2},
     ),
+    "mmlu_other_test_bpb_var": (
+        MMLU,
+        {"dataset_name": "other", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+    ),
+    "mmlu_other_test_bpb_5shot": (
+        MMLU,
+        {"dataset_name": "other", "split": "test", "prompt_variations": 1, "metric_type": "bpb"},
+    ),
     "mmlu_other_test_mc_5shot": (
         MMLU,
         {"dataset_name": "other", "split": "test", "prompt_variations": 2, "mc_labels": True},
+    ),
+
+    "mmlu_other_test_mc_5shot_fast": (
+        MMLU,
+        {"dataset_name": "other", "split": "test", "prompt_variations": 2, "mc_labels": True, "fast_mc": True},
     ),
 }
 


### PR DESCRIPTION
Add an option to specify MCQA tasks using 1 forward pass instead of 4 forward passes (only works with single-token continuations, will throw failure otherwise)

To test:

```sh
torchrun --nproc-per-node=1 src/scripts/train/OLMo2-ladder.py train 190M 5xC ai2/jupiter-cirrascale-2 \
    --trainer.callbacks.downstream_evaluator.eval_on_startup=true \
    --trainer.callbacks.downstream_evaluator.cancel_after_first_eval=true \
    --launch.num_gpus=1 \
    --ladder.save_folder=/tmp/debug \
    --trainer.save_folder=/tmp/debug \
    --launch.allow_dirty=True \
    --trainer.callbacks.downstream_evaluator.tasks=[arc_challenge_test_mc_5shot_fast,arc_challenge_test_mc_5shot]
```

Outputs:

```
2025-05-16 20:26:47.681 triton-cs-aus-454.reviz.ai2.in:0        olmo_core.train.callbacks.evaluator_callback:151    INFO     Finished downstream evals in 45.5 seconds. Metrics:
    arc_challenge_test_mc_5shot (accuracy)=0.2654
    arc_challenge_test_mc_5shot (accuracy v2)=0.2654
    arc_challenge_test_mc_5shot (CE loss)=11.76
    arc_challenge_test_mc_5shot (CE loss v2)=5.880
    arc_challenge_test_mc_5shot (BPB)=16.96
    arc_challenge_test_mc_5shot (BPB v2)=8.482
    arc_challenge_test_mc_5shot (soft loss)=0.2594
    arc_challenge_test_mc_5shot (soft loss v2)=0.2594
    arc_challenge_test_mc_5shot (log soft loss)=-2.13E+00
    arc_challenge_test_mc_5shot (log soft loss v2)=-2.13E+00
2025-05-16 20:27:00.868 triton-cs-aus-454.reviz.ai2.in:0        olmo_core.train.callbacks.evaluator_callback:151    INFO     Finished downstream evals in 13.2 seconds. Metrics:
    arc_challenge_test_mc_5shot_fast (accuracy)=0.2654
    arc_challenge_test_mc_5shot_fast (accuracy v2)=0.2654
    arc_challenge_test_mc_5shot_fast (CE loss)=11.76
    arc_challenge_test_mc_5shot_fast (CE loss v2)=5.880
    arc_challenge_test_mc_5shot_fast (BPB)=16.96
    arc_challenge_test_mc_5shot_fast (BPB v2)=8.482
    arc_challenge_test_mc_5shot_fast (soft loss)=0.2594
    arc_challenge_test_mc_5shot_fast (soft loss v2)=0.2594
    arc_challenge_test_mc_5shot_fast (log soft loss)=-2.13E+00
    arc_challenge_test_mc_5shot_fast (log soft loss v2)=-2.13E+00
2025-05-16 20:27:00.868 triton-cs-aus-454.reviz.ai2.in:0        olmo_core.train.callbacks.evaluator_callback:171    INFO     Evaluation speed:
    arc_challenge_test_mc_5shot_fast (accuracy) (+variants): 13.2 sec (23 batches)
    arc_challenge_test_mc_5shot (accuracy) (+variants): 45.5 sec (91 batches)
```

To test on the canonical task suite:

```sh
# Run on all tasks (slow)
torchrun --nproc-per-node=1 src/scripts/train/OLMo2-ladder.py train 1B 5xC ai2/jupiter-cirrascale-2 \
    --trainer.callbacks.downstream_evaluator.eval_on_startup=true \
    --trainer.callbacks.downstream_evaluator.cancel_after_first_eval=true \
    --launch.num_gpus=1 \
    --ladder.save_folder=/tmp/debug \
    --trainer.save_folder=/tmp/debug \
    --launch.allow_dirty=True \
    --trainer.callbacks.downstream_evaluator.tasks=[arc_challenge_test_mc_5shot,arc_easy_test_mc_5shot,hellaswag_rc_5shot,csqa_val_mc_5shot,piqa_val_mc_5shot,socialiqa_val_mc_5shot,winogrande_val_rc_5shot,mmlu_stem_val_mc_5shot,mmlu_humanities_val_mc_5shot,mmlu_social_sciences_val_mc_5shot,mmlu_other_val_mc_5shot,mmlu_stem_test_mc_5shot,mmlu_humanities_test_mc_5shot,mmlu_social_sciences_test_mc_5shot,mmlu_other_test_mc_5shot,gsm8k_gold_bpb_5shot,minerva_math_algebra_gold_bpb_0shot,minerva_math_counting_and_probability_gold_bpb_0shot,minerva_math_geometry_gold_bpb_0shot,minerva_math_intermediate_algebra_gold_bpb_0shot,minerva_math_number_theory_gold_bpb_0shot,minerva_math_prealgebra_gold_bpb_0shot,minerva_math_precalculus_gold_bpb_0shot,codex_humaneval_gold_bpb_0shot,codex_mbpp_gold_bpb_0shot,copycolors_10way]

# Run on all tasks (fast)
torchrun --nproc-per-node=1 src/scripts/train/OLMo2-ladder.py train 1B 5xC ai2/jupiter-cirrascale-2 \
    --trainer.callbacks.downstream_evaluator.eval_on_startup=true \
    --trainer.callbacks.downstream_evaluator.cancel_after_first_eval=true \
    --launch.num_gpus=1 \
    --ladder.save_folder=/tmp/debug \
    --trainer.save_folder=/tmp/debug \
    --launch.allow_dirty=True \
    --trainer.callbacks.downstream_evaluator.tasks=[arc_challenge_test_mc_5shot_fast,arc_easy_test_mc_5shot_fast,hellaswag_rc_5shot,csqa_val_mc_5shot_fast,piqa_val_mc_5shot_fast,socialiqa_val_mc_5shot_fast,winogrande_val_rc_5shot,mmlu_stem_val_mc_5shot_fast,mmlu_humanities_val_mc_5shot_fast,mmlu_social_sciences_val_mc_5shot_fast,mmlu_other_val_mc_5shot_fast,mmlu_stem_test_mc_5shot_fast,mmlu_humanities_test_mc_5shot_fast,mmlu_social_sciences_test_mc_5shot_fast,mmlu_other_test_mc_5shot_fast,gsm8k_gold_bpb_5shot,minerva_math_algebra_gold_bpb_0shot,minerva_math_counting_and_probability_gold_bpb_0shot,minerva_math_geometry_gold_bpb_0shot,minerva_math_intermediate_algebra_gold_bpb_0shot,minerva_math_number_theory_gold_bpb_0shot,minerva_math_prealgebra_gold_bpb_0shot,minerva_math_precalculus_gold_bpb_0shot,codex_humaneval_gold_bpb_0shot,codex_mbpp_gold_bpb_0shot,copycolors_10way_fast]
```

Output on original setup:

```sh
2025-05-16 21:22:15.614 triton-cs-aus-454.reviz.ai2.in:0        olmo_core.train.callbacks.evaluator_callback:171        INFO    Evaluation speed:
    copycolors_10way (accuracy) (+variants): 4.8 sec (10 batches)
    codex_humaneval_gold_bpb_0shot (BPB) (+variants): 5.3 sec (4 batches)
    mmlu_other_val_mc_5shot (length-normalized accuracy) (+variants): 15.2 sec (71 batches)
    codex_mbpp_gold_bpb_0shot (BPB) (+variants): 15.4 sec (30 batches)
    mmlu_social_sciences_val_mc_5shot (length-normalized accuracy) (+variants): 15.5 sec (75 batches)
    mmlu_stem_val_mc_5shot (length-normalized accuracy) (+variants): 15.6 sec (50 batches)
    winogrande_val_rc_5shot (length-normalized accuracy) (+variants): 16.6 sec (25 batches)
    piqa_val_mc_5shot (accuracy) (+variants): 34.2 sec (109 batches)
    minerva_math_counting_and_probability_gold_bpb_0shot (BPB) (+variants): 38.9 sec (37 batches)
    socialiqa_val_mc_5shot (accuracy) (+variants): 41.6 sec (85 batches)
    csqa_val_mc_5shot (accuracy) (+variants): 42.8 sec (89 batches)
    arc_challenge_test_mc_5shot (accuracy) (+variants): 43.6 sec (91 batches)
    mmlu_humanities_val_mc_5shot (length-normalized accuracy) (+variants): 44.3 sec (160 batches)
    minerva_math_number_theory_gold_bpb_0shot (BPB) (+variants): 48.9 sec (39 batches)
    minerva_math_prealgebra_gold_bpb_0shot (BPB) (+variants): 61.9 sec (55 batches)
    arc_easy_test_mc_5shot (accuracy) (+variants): 68.7 sec (183 batches)
    gsm8k_gold_bpb_5shot (BPB) (+variants): 69.0 sec (58 batches)
    minerva_math_geometry_gold_bpb_0shot (BPB) (+variants): 69.2 sec (37 batches)
    hellaswag_rc_5shot (length-normalized accuracy) (+variants): 84.3 sec (77 batches)
    minerva_math_precalculus_gold_bpb_0shot (BPB) (+variants): 94.2 sec (42 batches)
    minerva_math_algebra_gold_bpb_0shot (BPB) (+variants): 96.9 sec (92 batches)
    mmlu_other_test_mc_5shot (length-normalized accuracy) (+variants): 139.8 sec (721 batches)
    mmlu_social_sciences_test_mc_5shot (length-normalized accuracy) (+variants): 140.1 sec (684 batches)
    minerva_math_intermediate_algebra_gold_bpb_0shot (BPB) (+variants): 140.2 sec (70 batches)
    mmlu_stem_test_mc_5shot (length-normalized accuracy) (+variants): 142.4 sec (525 batches)
    mmlu_humanities_test_mc_5shot (length-normalized accuracy) (+variants): 397.5 sec (1448 batches)
    Total evaluation time: 1887.0 seconds (4867 batches)
```

Output on new setup:

```sh
2025-05-17 02:34:16.010 triton-cs-aus-454.reviz.ai2.in:0        olmo_core.train.callbacks.evaluator_callback:171        INFO       Evaluation speed:
    copycolors_10way_fast (accuracy) (+variants): 0.8 sec (1 batches)
    mmlu_stem_val_mc_5shot_fast (length-normalized accuracy) (+variants): 4.5 sec (13 batches)
    mmlu_other_val_mc_5shot_fast (length-normalized accuracy) (+variants): 4.6 sec (18 batches)
    mmlu_social_sciences_val_mc_5shot_fast (length-normalized accuracy) (+variants): 4.8 sec (19 batches)
    codex_humaneval_gold_bpb_0shot (BPB) (+variants): 4.8 sec (4 batches)
    csqa_val_mc_5shot_fast (accuracy) (+variants): 10.3 sec (18 batches)
    mmlu_humanities_val_mc_5shot_fast (length-normalized accuracy) (+variants): 12.3 sec (40 batches)
    codex_mbpp_gold_bpb_0shot (BPB) (+variants): 14.4 sec (30 batches)
    arc_challenge_test_mc_5shot_fast (accuracy) (+variants): 15.0 sec (23 batches)
    socialiqa_val_mc_5shot_fast (accuracy) (+variants): 15.2 sec (29 batches)
    winogrande_val_rc_5shot (length-normalized accuracy) (+variants): 15.7 sec (25 batches)
    piqa_val_mc_5shot_fast (accuracy) (+variants): 19.0 sec (55 batches)
    arc_easy_test_mc_5shot_fast (accuracy) (+variants): 20.5 sec (46 batches)
    minerva_math_counting_and_probability_gold_bpb_0shot (BPB) (+variants): 36.0 sec (37 batches)
    mmlu_stem_test_mc_5shot_fast (length-normalized accuracy) (+variants): 40.4 sec (132 batches)
    mmlu_social_sciences_test_mc_5shot_fast (length-normalized accuracy) (+variants): 40.4 sec (171 batches)
    mmlu_other_test_mc_5shot_fast (length-normalized accuracy) (+variants): 40.5 sec (181 batches)
    minerva_math_number_theory_gold_bpb_0shot (BPB) (+variants): 45.4 sec (39 batches)
    minerva_math_prealgebra_gold_bpb_0shot (BPB) (+variants): 58.1 sec (55 batches)
    minerva_math_geometry_gold_bpb_0shot (BPB) (+variants): 62.8 sec (37 batches)
    gsm8k_gold_bpb_5shot (BPB) (+variants): 65.0 sec (58 batches)
    hellaswag_rc_5shot (length-normalized accuracy) (+variants): 79.9 sec (77 batches)
    minerva_math_precalculus_gold_bpb_0shot (BPB) (+variants): 87.0 sec (42 batches)
    minerva_math_algebra_gold_bpb_0shot (BPB) (+variants): 88.7 sec (92 batches)
    mmlu_humanities_test_mc_5shot_fast (length-normalized accuracy) (+variants): 108.1 sec (362 batches)
    minerva_math_intermediate_algebra_gold_bpb_0shot (BPB) (+variants): 127.5 sec (70 batches)
    Total evaluation time: 1021.8 seconds (1674 batches)
```

**Here is new new and old config based on this**
```python
CURRENT_CONFIG = [
    # OLMES Core 9(-ish) RC
    "arc_challenge_test_rc_5shot",
    "arc_easy_test_rc_5shot",
    "hellaswag_rc_5shot",  # 1K subset of HellaSwag
    "winogrande_val_rc_5shot",  # Helpful after 750M-5xC scale
    "csqa_val_rc_5shot",
    "piqa_val_rc_5shot",
    "socialiqa_val_rc_5shot",
    # MMLU RC
    "mmlu_stem_val_rc_5shot",
    "mmlu_humanities_val_rc_5shot",
    "mmlu_social_sciences_val_rc_5shot",
    "mmlu_other_val_rc_5shot",
    "mmlu_stem_test_rc_5shot",
    "mmlu_humanities_test_rc_5shot",
    "mmlu_social_sciences_test_rc_5shot",
    "mmlu_other_test_rc_5shot",
    # OLMES Core 9(-ish) MC
    "arc_challenge_test_mc_5shot",
    "arc_easy_test_mc_5shot",
    "hellaswag_rc_5shot",  # 1K subset of HellaSwag
    "csqa_val_mc_5shot",
    "piqa_val_mc_5shot",
    "socialiqa_val_mc_5shot",
    "winogrande_val_rc_5shot",
    # MMLU MC BPB
    "mmlu_stem_val_mc_5shot",
    "mmlu_humanities_val_mc_5shot",
    "mmlu_social_sciences_val_mc_5shot",
    "mmlu_other_val_mc_5shot",
    "mmlu_stem_test_mc_5shot",
    "mmlu_humanities_test_mc_5shot",
    "mmlu_social_sciences_test_mc_5shot",
    "mmlu_other_test_mc_5shot",
    # Gen tasks BPB
    "gsm8k_gold_bpb_5shot",
    "minerva_math_algebra_gold_bpb_0shot",
    "minerva_math_counting_and_probability_gold_bpb_0shot",
    "minerva_math_geometry_gold_bpb_0shot",
    "minerva_math_intermediate_algebra_gold_bpb_0shot",
    "minerva_math_number_theory_gold_bpb_0shot",
    "minerva_math_prealgebra_gold_bpb_0shot",
    "minerva_math_precalculus_gold_bpb_0shot",
    "codex_humaneval_gold_bpb_0shot",
    "codex_mbpp_gold_bpb_0shot",
    # Sanity check for MCQA ability
    "copycolors_10way",
]

PROPOSED_CONFIG = [
    # OLMES Core 9(-ish) BPB
    "arc_challenge_test_bpb_5shot",
    "arc_easy_test_bpb_5shot",
    "hellaswag_bpb_5shot",  # 1K subset of HellaSwag
    # MMLU BPB
    "mmlu_stem_test_bpb_5shot",
    "mmlu_humanities_test_bpb_5shot",
    "mmlu_social_sciences_test_bpb_5shot",
    "mmlu_other_test_bpb_5shot",
    # OLMES Core 9(-ish) MC
    "arc_challenge_test_mc_5shot_fast",
    "arc_easy_test_mc_5shot_fast",
    # MMLU MC
    "mmlu_stem_test_mc_5shot_fast",
    "mmlu_humanities_test_mc_5shot_fast",
    "mmlu_social_sciences_test_mc_5shot_fast",
    "mmlu_other_test_mc_5shot_fast",
    # Gen tasks BPB
    "gsm8k_gold_bpb_5shot",
    "minerva_math_algebra_gold_bpb_0shot",
    "minerva_math_counting_and_probability_gold_bpb_0shot",
    "minerva_math_geometry_gold_bpb_0shot",
    "minerva_math_intermediate_algebra_gold_bpb_0shot",
    "minerva_math_number_theory_gold_bpb_0shot",
    "minerva_math_prealgebra_gold_bpb_0shot",
    "minerva_math_precalculus_gold_bpb_0shot",
    "codex_humaneval_gold_bpb_0shot",
    "codex_mbpp_gold_bpb_0shot",
    # Sanity check for MCQA ability
    "copycolors_10way_fast",
    # Basic Skills
    "basic_skills_arithmetic_rc_5shot",
    "basic_skills_coding_rc_5shot",
    "basic_skills_common_knowledge_rc_5shot",
    "basic_skills_logical_reasoning_rc_5shot",
    "basic_skills_pattern_rc_5shot",
    "basic_skills_string_operations_rc_5shot",
]
```

Here is the speed for that set:
```sh
2025-05-17 11:25:23.908 triton-cs-aus-454.reviz.ai2.in:0        olmo_core.train.callbacks.evaluator_callback:171        INFO    Evaluation speed:
    copycolors_10way_fast (accuracy) (+variants): 0.9 sec (1 batches)
    codex_humaneval_gold_bpb_0shot (BPB) (+variants): 5.1 sec (4 batches)
    arc_challenge_test_mc_5shot_fast (accuracy) (+variants): 12.1 sec (23 batches)
    arc_challenge_test_bpb_5shot (BPB) (+variants): 12.5 sec (17 batches)
    codex_mbpp_gold_bpb_0shot (BPB) (+variants): 15.1 sec (30 batches)
    arc_easy_test_bpb_5shot (BPB) (+variants): 15.8 sec (35 batches)
    arc_easy_test_mc_5shot_fast (accuracy) (+variants): 20.9 sec (46 batches)
    hellaswag_bpb_5shot (BPB) (+variants): 21.1 sec (20 batches)
    mmlu_social_sciences_test_bpb_5shot (BPB) (+variants): 31.9 sec (76 batches)
    mmlu_other_test_bpb_5shot (BPB) (+variants): 33.9 sec (141 batches)
    mmlu_stem_test_bpb_5shot (BPB) (+variants): 34.0 sec (105 batches)
    minerva_math_counting_and_probability_gold_bpb_0shot (BPB) (+variants): 39.6 sec (37 batches)
    mmlu_stem_test_mc_5shot_fast (length-normalized accuracy) (+variants): 40.9 sec (132 batches)
    mmlu_social_sciences_test_mc_5shot_fast (length-normalized accuracy) (+variants): 41.0 sec (171 batches)
    mmlu_other_test_mc_5shot_fast (length-normalized accuracy) (+variants): 41.2 sec (181 batches)
    minerva_math_number_theory_gold_bpb_0shot (BPB) (+variants): 48.8 sec (39 batches)
    minerva_math_prealgebra_gold_bpb_0shot (BPB) (+variants): 63.4 sec (55 batches)
    minerva_math_geometry_gold_bpb_0shot (BPB) (+variants): 68.5 sec (37 batches)
    gsm8k_gold_bpb_5shot (BPB) (+variants): 68.5 sec (58 batches)
    minerva_math_precalculus_gold_bpb_0shot (BPB) (+variants): 96.7 sec (42 batches)
    minerva_math_algebra_gold_bpb_0shot (BPB) (+variants): 97.0 sec (92 batches)
    mmlu_humanities_test_bpb_5shot (BPB) (+variants): 102.5 sec (362 batches)
    mmlu_humanities_test_mc_5shot_fast (length-normalized accuracy) (+variants): 109.9 sec (362 batches)
    minerva_math_intermediate_algebra_gold_bpb_0shot (BPB) (+variants): 137.0 sec (70 batches)
    Total evaluation time: 1158.4 seconds (2136 batches)
```