### PR TITLE
Fix speed on BPB/RC evals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v0.8.3](https://github.com/allenai/OLMo-in-loop-evals/releases/tag/v0.8.3) - 2025-05-27
+
+- Fix speed problem for BPB/RC tasks
+
 ## [v0.8.2](https://github.com/allenai/OLMo-in-loop-evals/releases/tag/v0.8.2) - 2025-05-17
 
 - Add few-shot HumanEval

--- a/src/olmo_eval/metrics.py
+++ b/src/olmo_eval/metrics.py
@@ -103,7 +103,7 @@ class ICLMetric(Metric):
                 choice_ids = batch["choice_ids"][idx]
             else:
                 fast_mc = False
-                choice_ids = cont_tokens
+                choice_ids = [cont_tokens]
 
             # For each choice token, calculate metrics and append as separate entries
             for choice_idx, choice_token in enumerate(choice_ids):

--- a/src/olmo_eval/version.py
+++ b/src/olmo_eval/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "0"
 _MINOR = "8"
-_PATCH = "2"
+_PATCH = "3"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)


### PR DESCRIPTION
Mayee noticed that the in-loop evals after this commit were 4x slower as a result of https://github.com/allenai/OLMo-in-loop-evals/commit/b635bb93dc9566a9a95aa39e2136cc11cc6900e4

The culprit is logic in when we don't use `fast_mc`. Instead of running evals once, it runs evals for each token in the continuation (and then throws out all but 1 pass).

```python
choice_ids = cont_tokens # tensor: (toks, 1)

for choice_idx, choice_token in enumerate(choice_ids):
    ...
```

Testing this fix, the numbers are the same, but the fixed version is much faster:
```sh
# before fix:
INFO    Finished downstream evals in 56.1 seconds. Metrics:
    minerva_math_precalculus_gold_bpb_0shot (BPB)=7.557
    minerva_math_precalculus_gold_bpb_0shot (BPB v2)=7.539

# after fix:
INFO    Finished downstream evals in 14.8 seconds. Metrics:
    minerva_math_precalculus_gold_bpb_0shot (BPB)=7.557
    minerva_math_precalculus_gold_bpb_0shot (BPB v2)=7.539
```

**To be clear, the eval results are the same before/after the fix, just that the evals are faster.**
