### PR TITLE
add bos token if in tokenizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v0.8.4](https://github.com/allenai/OLMo-in-loop-evals/releases/tag/v0.8.4) - 2025-06-05
+
+- Add BOS token, when the BOS token exists in the tokenizer
+
 ## [v0.8.3](https://github.com/allenai/OLMo-in-loop-evals/releases/tag/v0.8.3) - 2025-05-27
 
 - Fix speed problem for BPB/RC tasks

--- a/src/olmo_eval/tasks.py
+++ b/src/olmo_eval/tasks.py
@@ -96,7 +96,10 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
                 ctx = self.token_encode(doc_text)
 
                 # Add BOS token if it is exists in the tokenizer
-                if self.tokenizer.bos_token_id is not None and ctx[0] != self.tokenizer.bos_token_id:
+                if (
+                    self.tokenizer.bos_token_id is not None
+                    and ctx[0] != self.tokenizer.bos_token_id
+                ):
                     ctx = [self.tokenizer.bos_token_id] + ctx
 
                 if doc_id == 0:
@@ -562,7 +565,10 @@ class WinoGrande(ICLMultiChoiceTaskDataset):
                 ctx = self.token_encode(ctx)
 
                 # Add BOS token if it is exists in the tokenizer
-                if self.tokenizer.bos_token_id is not None and ctx[0] != self.tokenizer.bos_token_id:
+                if (
+                    self.tokenizer.bos_token_id is not None
+                    and ctx[0] != self.tokenizer.bos_token_id
+                ):
                     ctx = [self.tokenizer.bos_token_id] + ctx
 
                 if doc_id == 0:
@@ -1626,7 +1632,10 @@ class OEEvalTask(ICLMultiChoiceTaskDataset):
                 ctx = self.token_encode(doc_text)
 
                 # Add BOS token if it is exists in the tokenizer
-                if self.tokenizer.bos_token_id is not None and ctx[0] != self.tokenizer.bos_token_id:
+                if (
+                    self.tokenizer.bos_token_id is not None
+                    and ctx[0] != self.tokenizer.bos_token_id
+                ):
                     ctx = [self.tokenizer.bos_token_id] + ctx
 
                 if doc_id == 0:

--- a/src/olmo_eval/tasks.py
+++ b/src/olmo_eval/tasks.py
@@ -358,8 +358,7 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
         return batch
 
     def token_encode(self, string: str) -> List[int]:
-        encoding = self.tokenizer.encode(string, add_special_tokens=False)
-        return encoding
+        return self.tokenizer.encode(string, add_special_tokens=False)
 
     def token_decode(self, tokens: List[int]) -> str:
         return self.tokenizer.decode(tokens)
@@ -568,7 +567,7 @@ class WinoGrande(ICLMultiChoiceTaskDataset):
 
                 if doc_id == 0:
                     log.info(f"First tokens of in-loop eval context: {ctx[:5]}")
-                    
+
                 dc = self.token_encode(dc)
 
                 # query, remove last token from continuation, truncate from left is longer than model ctx length

--- a/src/olmo_eval/tasks.py
+++ b/src/olmo_eval/tasks.py
@@ -94,6 +94,14 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
                 label_id = self.doc_to_label(doc)
                 doc_text = self.doc_to_text(doc)
                 ctx = self.token_encode(doc_text)
+
+                # Add BOS token if it is exists in the tokenizer
+                if self.tokenizer.bos_token_id is not None and ctx[0] != self.tokenizer.bos_token_id:
+                    ctx = [self.tokenizer.bos_token_id] + ctx
+
+                if doc_id == 0:
+                    log.info(f"First tokens of in-loop eval context: {ctx[:5]}")
+
                 dc = self.token_encode(self.doc_to_domain_conditional(doc))
                 if self.log_instances > 0:
                     self.log_instances -= 1
@@ -350,7 +358,8 @@ class ICLMultiChoiceTaskDataset(metaclass=abc.ABCMeta):
         return batch
 
     def token_encode(self, string: str) -> List[int]:
-        return self.tokenizer.encode(string, add_special_tokens=False)
+        encoding = self.tokenizer.encode(string, add_special_tokens=False)
+        return encoding
 
     def token_decode(self, tokens: List[int]) -> str:
         return self.tokenizer.decode(tokens)
@@ -552,6 +561,14 @@ class WinoGrande(ICLMultiChoiceTaskDataset):
 
             for cont_id, (ctx, dc) in enumerate(zip(ctxs, dcs)):
                 ctx = self.token_encode(ctx)
+
+                # Add BOS token if it is exists in the tokenizer
+                if self.tokenizer.bos_token_id is not None and ctx[0] != self.tokenizer.bos_token_id:
+                    ctx = [self.tokenizer.bos_token_id] + ctx
+
+                if doc_id == 0:
+                    log.info(f"First tokens of in-loop eval context: {ctx[:5]}")
+                    
                 dc = self.token_encode(dc)
 
                 # query, remove last token from continuation, truncate from left is longer than model ctx length
@@ -1608,6 +1625,14 @@ class OEEvalTask(ICLMultiChoiceTaskDataset):
                         label_id = 0
                 doc_text = request_dict["context"]
                 ctx = self.token_encode(doc_text)
+
+                # Add BOS token if it is exists in the tokenizer
+                if self.tokenizer.bos_token_id is not None and ctx[0] != self.tokenizer.bos_token_id:
+                    ctx = [self.tokenizer.bos_token_id] + ctx
+
+                if doc_id == 0:
+                    log.info(f"First tokens of in-loop eval context: {ctx[:5]}")
+
                 dc = self.token_encode(self.doc_to_domain_conditional(doc))
                 if self.log_instances > 0:
                     self.log_instances -= 1

--- a/src/olmo_eval/version.py
+++ b/src/olmo_eval/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "0"
 _MINOR = "8"
-_PATCH = "3"
+_PATCH = "4"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)


### PR DESCRIPTION
Adds BOS tokenization to in-loop evals, to match downstream. Adding the BOS token is based on whether the tokenizer is initialized with a `bos_token_id`. See `tokenizer.py` in olmo-core:

https://github.com/allenai/OLMo-core/blob/main/src/olmo_core/data/tokenizer.py#L71-L106

You can manually set this flag in the trainer. For example: `--ladder.tokenizer.bos_token_id=100257`.

### Sanity check

```sh
# BOS tokenization
torchrun --nproc-per-node=1 src/scripts/train/OLMo2-ladder.py train 1B 5xC ai2/jupiter-cirrascale-2 \
    --trainer.callbacks.downstream_evaluator.eval_on_startup=true \
    --trainer.callbacks.downstream_evaluator.cancel_after_first_eval=true \
    --launch.num_gpus=1 \
    --ladder.save_folder=/tmp/debug \
    --trainer.save_folder=/tmp/debug \
    --launch.allow_dirty=True \
    --trainer.callbacks.downstream_evaluator.tasks=[arc_challenge_test_rc_5shot] \
    --ladder.tokenizer.bos_token_id=100257

# without BOS tokenization
torchrun --nproc-per-node=1 src/scripts/train/OLMo2-ladder.py train 1B 5xC ai2/jupiter-cirrascale-2 \
    --trainer.callbacks.downstream_evaluator.eval_on_startup=true \
    --trainer.callbacks.downstream_evaluator.cancel_after_first_eval=true \
    --launch.num_gpus=1 \
    --ladder.save_folder=/tmp/debug \
    --trainer.save_folder=/tmp/debug \
    --launch.allow_dirty=True \
    --trainer.callbacks.downstream_evaluator.tasks=[arc_challenge_test_rc_5shot]
```

Here are the results on the above commands:

```sh
# BOS tokenization
INFO    First tokens of in-loop eval context: [100257, 14924, 25, 10058, 6944]
...
INFO    Finished downstream evals in 28.0 seconds. Metrics:
    arc_challenge_test_rc_5shot (length-normalized accuracy)=0.2773
    arc_challenge_test_rc_5shot (length-normalized accuracy v2)=0.2773
    arc_challenge_test_rc_5shot (CE loss)=2.909
    arc_challenge_test_rc_5shot (CE loss v2)=2.623
    arc_challenge_test_rc_5shot (BPB)=4.186
    arc_challenge_test_rc_5shot (BPB v2)=3.777
    arc_challenge_test_rc_5shot (soft loss)=0.2523
    arc_challenge_test_rc_5shot (soft loss v2)=0.2522
    arc_challenge_test_rc_5shot (log soft loss)=-1.50E+00
    arc_challenge_test_rc_5shot (log soft loss v2)=-1.45E+00

# without BOS tokenization
INFO    First tokens of in-loop eval context: [14924, 25, 10058, 6944, 311]
...
Finished downstream evals in 39.0 seconds. Metrics:
    arc_challenge_test_rc_5shot (length-normalized accuracy)=0.2671
    arc_challenge_test_rc_5shot (length-normalized accuracy v2)=0.2671
    arc_challenge_test_rc_5shot (CE loss)=2.908
    arc_challenge_test_rc_5shot (CE loss v2)=2.621
    arc_challenge_test_rc_5shot (BPB)=4.185
    arc_challenge_test_rc_5shot (BPB v2)=3.774
    arc_challenge_test_rc_5shot (soft loss)=0.2516
    arc_challenge_test_rc_5shot (soft loss v2)=0.2517
    arc_challenge_test_rc_5shot (log soft loss)=-1.50E+00
    arc_challenge_test_rc_5shot (log soft loss v2)=-1.45E+00
```