### PR TITLE
remove sklearn/numpy deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v0.8.5](https://github.com/allenai/OLMo-in-loop-evals/releases/tag/v0.8.4) - 2025-06-05
+
+- Remove `sklearn` and `numpy` as depedencies. Manual implementation of F1 score.
+
 ## [v0.8.4](https://github.com/allenai/OLMo-in-loop-evals/releases/tag/v0.8.4) - 2025-06-05
 
 - Add BOS token, when the BOS token exists in the tokenizer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-## [v0.8.5](https://github.com/allenai/OLMo-in-loop-evals/releases/tag/v0.8.4) - 2025-06-05
+### Removed
 
 - Remove `sklearn` and `numpy` as depedencies. Manual implementation of F1 score.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,10 @@ authors = [
 requires-python = ">=3.9"
 license = { file = "LICENSE" }
 dependencies = [
-    "numpy<2.0",
     "torch",
     "torchmetrics",
     "datasets",
     "tokenizers",
-    "scikit-learn",
     "cached-path",
     "requests",
     "packaging",

--- a/src/olmo_eval/metrics.py
+++ b/src/olmo_eval/metrics.py
@@ -395,7 +395,9 @@ class ICLMetric(Metric):
             assert labels is not None
             # for NLI tasks, continuations are yes, no, neither, so idx=0 assigned to pos label
             score = self.custom_f1_score(labels, preds, pos_label=0)
-            score_no_leading_space = self.custom_f1_score(labels, preds_no_leading_space, pos_label=0)
+            score_no_leading_space = self.custom_f1_score(
+                labels, preds_no_leading_space, pos_label=0
+            )
             return {
                 "f1_v1": torch.tensor(score),
                 "f1_v2": torch.tensor(score_no_leading_space),

--- a/src/olmo_eval/metrics.py
+++ b/src/olmo_eval/metrics.py
@@ -3,7 +3,6 @@ from typing import Any, Dict, List, Optional, Tuple, TypeVar
 
 import torch
 import torch.nn.functional as F
-from sklearn.metrics import f1_score
 from torchmetrics import Metric
 
 from .util import all_gather_object
@@ -395,8 +394,8 @@ class ICLMetric(Metric):
             assert preds is not None
             assert labels is not None
             # for NLI tasks, continuations are yes, no, neither, so idx=0 assigned to pos label
-            score = f1_score(labels, preds, pos_label=0)
-            score_no_leading_space = f1_score(labels, preds_no_leading_space, pos_label=0)
+            score = self.custom_f1_score(labels, preds, pos_label=0)
+            score_no_leading_space = self.custom_f1_score(labels, preds_no_leading_space, pos_label=0)
             return {
                 "f1_v1": torch.tensor(score),
                 "f1_v2": torch.tensor(score_no_leading_space),
@@ -432,3 +431,21 @@ class ICLMetric(Metric):
                 ),
                 "soft_log_v2": torch.tensor(sum(soft_log_score) / len(soft_log_score)),
             }
+
+    def custom_f1_score(y_true, y_pred, pos_label=1):
+        y_true = list(y_true)
+        y_pred = list(y_pred)
+        tp = sum((yt == pos_label) and (yp == pos_label) for yt, yp in zip(y_true, y_pred))
+        fp = sum((yt != pos_label) and (yp == pos_label) for yt, yp in zip(y_true, y_pred))
+        fn = sum((yt == pos_label) and (yp != pos_label) for yt, yp in zip(y_true, y_pred))
+
+        if tp + fp == 0 or tp + fn == 0:
+            return 0.0
+
+        precision = tp / (tp + fp)
+        recall = tp / (tp + fn)
+
+        if precision + recall == 0:
+            return 0.0
+
+        return 2 * precision * recall / (precision + recall)

--- a/src/olmo_eval/metrics.py
+++ b/src/olmo_eval/metrics.py
@@ -434,7 +434,7 @@ class ICLMetric(Metric):
                 "soft_log_v2": torch.tensor(sum(soft_log_score) / len(soft_log_score)),
             }
 
-    def custom_f1_score(y_true, y_pred, pos_label=1):
+    def custom_f1_score(self, y_true, y_pred, pos_label=1):
         y_true = list(y_true)
         y_pred = list(y_pred)
         tp = sum((yt == pos_label) and (yp == pos_label) for yt, yp in zip(y_true, y_pred))

--- a/src/olmo_eval/version.py
+++ b/src/olmo_eval/version.py
@@ -1,6 +1,6 @@
 _MAJOR = "0"
 _MINOR = "8"
-_PATCH = "4"
+_PATCH = "5"
 _SUFFIX = ""
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)


### PR DESCRIPTION
Remove `sklearn` which was being used to compute F1 score. Adds a custom implementation.

This function shows equivalence between the two implementations:

```
from sklearn.metrics import f1_score as sklearn_f1

def custom_f1_score(y_true, y_pred, pos_label=1):
    y_true = list(y_true)
    y_pred = list(y_pred)
    tp = sum((yt == pos_label) and (yp == pos_label) for yt, yp in zip(y_true, y_pred))
    fp = sum((yt != pos_label) and (yp == pos_label) for yt, yp in zip(y_true, y_pred))
    fn = sum((yt == pos_label) and (yp != pos_label) for yt, yp in zip(y_true, y_pred))

    if tp + fp == 0 or tp + fn == 0:
        return 0.0

    precision = tp / (tp + fp)
    recall = tp / (tp + fn)

    if precision + recall == 0:
        return 0.0

    return 2 * precision * recall / (precision + recall)

# Test
labels = [0, 1, 0, 1, 0, 0, 1]
preds = [0, 1, 1, 1, 0, 0, 0]
preds_no_leading_space = [0, 1, 0, 1, 1, 0, 0]

score_sklearn = sklearn_f1(labels, preds, pos_label=0)
score_custom = custom_f1_score(labels, preds, pos_label=0)

score_sklearn_no_leading = sklearn_f1(labels, preds_no_leading_space, pos_label=0)
score_custom_no_leading = custom_f1_score(labels, preds_no_leading_space, pos_label=0)

def isclose(a, b, rel_tol=1e-9, abs_tol=0.0):
    return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)

assert isclose(score_custom, score_sklearn)
assert isclose(score_custom_no_leading, score_sklearn_no_leading)
```